### PR TITLE
add server to serve API docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,55 @@
 'use strict';
 
 var Dredd = require('dredd');
+var express = require('express');
+var fs = require('fs');
+var markdown = require('marked');
 var path = require('path');
+
+var server = module.exports.server = express();
+
+server.use(express.static(__dirname));
+
+server.get('/', function (req, res) {
+	module.exports.getSpecHtml(function (err, html) {
+		if (err) {
+			throw err;
+		}
+
+		res.end(html);
+	});
+});
+
+module.exports.getSpecHtml = function (callback) {
+	var blueprintPath = require.resolve('todomvc-api/todos.apib');
+
+	fs.readFile(blueprintPath, function (err, blueprint) {
+		if (err) {
+			return callback(err);
+		}
+
+		var cssPath = require.resolve('github-markdown-css/github-markdown.css');
+		var body = markdown(blueprint.toString().replace(/^FORMAT.*/, ''));
+
+		callback(null, [
+			'<!doctype html>',
+			'<html lang="en">',
+			'	<head>',
+			'		<meta charset="utf-8">',
+			'		<title>TodoMVC API Blueprint</title>',
+			'		<link rel="stylesheet" href="' + path.relative(__dirname, cssPath) + '">',
+			'		<style>',
+			'			body { background: #eee; }',
+			'			.markdown-body { background: #fff; width:790px; margin: 30px auto; padding: 30px; }',
+			'		</style>',
+			'	</head>',
+			'	<body>',
+			'		<article class="markdown-body">' + body + '</article>',
+			'	</body>',
+			'</html>'
+		].join('\n'));
+	});
+};
 
 module.exports.validate = function (serverUrl, cb) {
 	if (typeof serverUrl === 'function') {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "async": "^0.9.0",
     "dredd": "^0.3.9",
+    "express": "^4.10.1",
+    "github-markdown-css": "^1.2.0",
+    "marked": "^0.3.2",
     "request": "^2.45.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var api = require("./");
+
+api.server.listen(8080);


### PR DESCRIPTION
`npm start` will serve the API on `GET /`

A BE implementation can get the express instance with `require("todomvc-api").server`, and can get just the HTML to display the API spec with `require("todomvc-api").getSpecHtml`
